### PR TITLE
produces country codes in a safely manner

### DIFF
--- a/intl_tel_widget/static/src/js/phone_widget.js
+++ b/intl_tel_widget/static/src/js/phone_widget.js
@@ -23,8 +23,11 @@ let CountryService = Class.extend({
             args: [[], ['id', 'code']],
         }).then(function (result) {
             result.forEach(function (item) {
-                self.countries[item.id] = item.code.toLowerCase();
-                self.codes[item.code.toLowerCase()] = item.id;
+                if(item.code){
+                    let country_code = item.code.toLowerCase();
+                    self.countries[item.id] = country_code;
+                    self.codes[country_code] = item.id;
+                }
             });
         });
     },


### PR DESCRIPTION
When this plugin was enabled on a site, it started to yell error like `item.code.toLowerCase is not a function` in the backend. Maybe because some country configuration related to the site. So this fix this kind of scenario.